### PR TITLE
add rule provide-print-css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#22](https://github.com/green-code-initiative/ecoCode-javascript/pull/22) Add rule `@ecocode/provide-print-css`
 - [#14](https://github.com/green-code-initiative/ecoCode-javascript/pull/14) Create SonarQube plugin
 - [#12](https://github.com/green-code-initiative/ecoCode-javascript/issues/12) Pack ESLint plugin into SonarQube plugin
 - [#16](https://github.com/green-code-initiative/ecoCode-javascript/pull/16) Use centralized rules specifications

--- a/eslint-plugin/README.md
+++ b/eslint-plugin/README.md
@@ -62,10 +62,10 @@ Add `@ecocode` to the `plugins` section of your `.eslintrc`, followed by rules c
 | [limit-db-query-results](docs/rules/limit-db-query-results.md)                         | Should limit the number of returns for a SQL query         | ✅  |
 | [no-empty-image-src-attribute](docs/rules/no-empty-image-src-attribute.md)             | Disallow usage of image with empty source attribute        | ✅  |
 | [no-import-all-from-library](docs/rules/no-import-all-from-library.md)                 | Should not import all from library                         | ✅  |
-| [provide-print-css](docs/rules/provide-print-css.md)                             | Enforce providing a print stylesheet                       | ✅  |
 | [no-multiple-access-dom-element](docs/rules/no-multiple-access-dom-element.md)         | Disallow multiple access of same DOM element.              | ✅  |
 | [no-multiple-style-changes](docs/rules/no-multiple-style-changes.md)                   | Disallow multiple style changes at once.                   | ✅  |
 | [prefer-collections-with-pagination](docs/rules/prefer-collections-with-pagination.md) | Prefer API collections with pagination.                    | ✅  |
+| [provide-print-css](docs/rules/provide-print-css.md)                                   | Enforce providing a print stylesheet                       | ✅  |
 
 <!-- end auto-generated rules list -->
 

--- a/eslint-plugin/README.md
+++ b/eslint-plugin/README.md
@@ -60,6 +60,7 @@ Add `@ecocode` to the `plugins` section of your `.eslintrc`, followed by rules c
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------- | :- |
 | [avoid-high-accuracy-geolocation](docs/rules/avoid-high-accuracy-geolocation.md)       | Avoid using high accuracy geolocation in web applications. | ✅  |
 | [no-import-all-from-library](docs/rules/no-import-all-from-library.md)                 | Should not import all from library                         | ✅  |
+| [provide-print-css](docs/rules/provide-print-css.md)                             | Enforce providing a print stylesheet                       | ✅  |
 | [no-multiple-access-dom-element](docs/rules/no-multiple-access-dom-element.md)         | Disallow multiple access of same DOM element.              | ✅  |
 | [no-multiple-style-changes](docs/rules/no-multiple-style-changes.md)                   | Disallow multiple style changes at once.                   | ✅  |
 | [prefer-collections-with-pagination](docs/rules/prefer-collections-with-pagination.md) | Prefer API collections with pagination.                    | ✅  |

--- a/eslint-plugin/docs/rules/provide-print-css.md
+++ b/eslint-plugin/docs/rules/provide-print-css.md
@@ -1,0 +1,27 @@
+# Enforce providing a print stylesheet (`@ecocode/provide-print-css`)
+
+⚠️ This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule aims to remind developers to use CSS print to limit the number of pages printed therefore indirectly reducing the impact of the web page.
+
+## Examples
+
+Examples of **non-compliant** code for this rule:
+
+```js
+<link rel="stylesheet" type="text/css" href="styles.css">
+```
+
+Examples of **compliant** code for this rule:
+
+```js
+<style>
+    @media print {
+      /* Print-specific styles */
+    }
+</style>
+```

--- a/eslint-plugin/docs/rules/provide-print-css.md
+++ b/eslint-plugin/docs/rules/provide-print-css.md
@@ -6,22 +6,41 @@
 
 ## Rule Details
 
-This rule aims to remind developers to use CSS print to limit the number of pages printed therefore indirectly reducing the impact of the web page.
+This rule aims to remind developers to use CSS print to limit the number of pages printed therefore indirectly reducing
+the impact of the web page.
 
 ## Examples
 
 Examples of **non-compliant** code for this rule:
 
-```js
-<link rel="stylesheet" type="text/css" href="styles.css">
+```html
+<head>
+  <title>Web Page</title>
+  <link rel="stylesheet" type="text/css" href="styles.css" />
+</head>
 ```
 
 Examples of **compliant** code for this rule:
 
-```js
-<style>
+```html
+<head>
+  <title>Web Page</title>
+  <link rel="stylesheet" media="print" type="text/css" href="print.css" />
+</head>
+```
+
+```html
+<head>
+  <title>Web Page</title>
+  <style>
     @media print {
       /* Print-specific styles */
     }
-</style>
+  </style>
+</head>
 ```
+
+## Further details
+
+This recommendation is made by the
+CNUMR: [Provide a print CSS](https://github.com/cnumr/best-practices/blob/main/chapters/BP_027_en.md)

--- a/eslint-plugin/lib/rules/provide-print-css.js
+++ b/eslint-plugin/lib/rules/provide-print-css.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2023 Green Code Initiative
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+"use strict";
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce providing a print stylesheet",
+      category: "eco-design",
+      recommended: "warn",
+    },
+    messages: {
+      noPrintCSSProvided: "Provide a print CSS",
+    },
+    schema: [],
+  },
+  create(context) {
+    // Track scanned files
+    const scannedFiles = new Set();
+    return {
+      JSXElement(node) {
+        const filePath = context.getFilename();
+
+        // Skip if file has already been scanned
+        if (scannedFiles.has(filePath)) {
+          return;
+        }
+
+        // Mark file as scanned
+        scannedFiles.add(filePath);
+        if (
+          node.openingElement.name.name === "link" &&
+          node.openingElement.attributes.some(
+            (attr) =>
+              attr.name.name === "media" && attr.value.value === "print",
+          )
+        ) {
+          return;
+        } else if (
+          node.openingElement.name.name === "style" &&
+          node.children.some((child) => child.value.includes("@media print"))
+        ) {
+          return;
+        }
+
+        context.report({
+          node: node,
+          messageId: "noPrintCSSProvided",
+        });
+      },
+    };
+  },
+};

--- a/eslint-plugin/tests/lib/rules/provide-print-css.js
+++ b/eslint-plugin/tests/lib/rules/provide-print-css.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2023 Green Code Initiative
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/provide-print-css");
+const RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+const expectedError = {
+  messageId: "noPrintCSSProvided",
+  type: "JSXElement",
+};
+
+ruleTester.run("provide-print-css", rule, {
+  valid: [
+    `
+    <link rel="stylesheet" href="styles.css" media="print" />
+
+    `,
+    `
+    <style>
+    @media print {
+      /* Print-specific styles */
+    }
+    </style>
+    `,
+    `
+    {<link rel="stylesheet" href="styles.css" media="print" />,
+    <style>
+      @media print {
+        /* Print-specific styles */
+      }
+    </style>}    
+    `,
+  ],
+  invalid: [
+    {
+      code: `<link rel="stylesheet" href="styles.css" />`,
+      errors: [expectedError],
+    },
+  ],
+});

--- a/eslint-plugin/tests/lib/rules/provide-print-css.js
+++ b/eslint-plugin/tests/lib/rules/provide-print-css.js
@@ -36,6 +36,7 @@ const ruleTester = new RuleTester({
     },
   },
 });
+
 const expectedError = {
   messageId: "noPrintCSSProvided",
   type: "JSXElement",
@@ -44,28 +45,50 @@ const expectedError = {
 ruleTester.run("provide-print-css", rule, {
   valid: [
     `
-    <link rel="stylesheet" href="styles.css" media="print" />
-
+    <head>
+      <title>Web Page</title>
+      <link rel="stylesheet" href="styles.css" media="print" />
+    </head>
     `,
     `
-    <style>
-    @media print {
-      /* Print-specific styles */
-    }
-    </style>
+    <head>
+      <title>Web Page</title>
+      <style>@media print {}</style>
+    </head>
     `,
     `
-    {<link rel="stylesheet" href="styles.css" media="print" />,
-    <style>
-      @media print {
-        /* Print-specific styles */
-      }
-    </style>}    
+    <head>
+      <title>Web Page</title>
+      <style>{'@media print {}'}</style>
+    </head>
     `,
+    `
+    <head>
+      <title>Web Page</title>
+      <link rel="stylesheet" href="styles.css" media="print" />,
+      <style>{'@media print {}'}</style>
+    </head>   
+    `,
+    "<head><style>{`@media print {}`}</style></head>",
+    `<link rel="stylesheet" href="styles.css" />`,
   ],
   invalid: [
     {
-      code: `<link rel="stylesheet" href="styles.css" />`,
+      code: `
+        <head>
+          <title>Web Page</title>
+          <link rel="stylesheet" href="styles.css" />
+        </head>
+      `,
+      errors: [expectedError],
+    },
+    {
+      code: `
+        <head>
+          <title>Web Page</title>
+          <style>{'@media desktop {}'}</style>
+        </head>
+      `,
       errors: [expectedError],
     },
   ],


### PR DESCRIPTION
this rule aims to reming the developper to privide a print css to allow a more efficient and economical print