### PR TITLE
Remove trailing dots at the end of descriptions to stick to Sonar way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--   [#52](https://github.com/green-code-initiative/ecoCode-javascript/pull/52) Remove trailing dots in Sonar rules 
-    descriptions
-
 ### Added
 
 -   [#39](https://github.com/green-code-initiative/ecoCode-javascript/issues/39) Add rule `@ecocode/avoid-brightness-override` (EC522)
@@ -19,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   [#44](https://github.com/green-code-initiative/ecoCode-javascript/pull/44) Implement the rule EC523 for React Native
+-   [#52](https://github.com/green-code-initiative/ecoCode-javascript/pull/52) Remove trailing dots in Sonar rules descriptions
 -   Update Docker Compose configuration file to V2
 
 ### Deleted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   [#52](https://github.com/green-code-initiative/ecoCode-javascript/pull/52) Remove trailing dots in Sonar rules 
+    descriptions
+
 ### Added
 
 -   [#39](https://github.com/green-code-initiative/ecoCode-javascript/issues/39) Add rule `@ecocode/avoid-brightness-override` (EC522)

--- a/eslint-plugin/README.md
+++ b/eslint-plugin/README.md
@@ -67,20 +67,20 @@ Add `@ecocode` to the `plugins` section of your `.eslintrc`, followed by rules c
 ⚠️ Configurations set to warn in.\
 ✅ Set in the `recommended` configuration.
 
-| Name                                                                                   | Description                                                | ⚠️ |
-| :------------------------------------------------------------------------------------- | :--------------------------------------------------------- | :- |
-| [avoid-brightness-override](docs/rules/avoid-brightness-override.md)                   | Should avoid to override brightness                        | ✅  |
-| [avoid-css-animations](docs/rules/avoid-css-animations.md)                             | Avoid usage of CSS animations                              | ✅  |
-| [avoid-high-accuracy-geolocation](docs/rules/avoid-high-accuracy-geolocation.md)       | Avoid using high accuracy geolocation in web applications. | ✅  |
-| [limit-db-query-results](docs/rules/limit-db-query-results.md)                         | Should limit the number of returns for a SQL query         | ✅  |
-| [no-empty-image-src-attribute](docs/rules/no-empty-image-src-attribute.md)             | Disallow usage of image with empty source attribute        | ✅  |
-| [no-import-all-from-library](docs/rules/no-import-all-from-library.md)                 | Should not import all from library                         | ✅  |
-| [no-multiple-access-dom-element](docs/rules/no-multiple-access-dom-element.md)         | Disallow multiple access of same DOM element.              | ✅  |
-| [no-multiple-style-changes](docs/rules/no-multiple-style-changes.md)                   | Disallow multiple style changes at once.                   | ✅  |
-| [no-torch](docs/rules/no-torch.md)                                                     | Should not programmatically enable torch mode              | ✅  |
-| [prefer-collections-with-pagination](docs/rules/prefer-collections-with-pagination.md) | Prefer API collections with pagination.                    | ✅  |
-| [prefer-shorthand-css-notations](docs/rules/prefer-shorthand-css-notations.md)         | Encourage usage of shorthand CSS notations                 | ✅  |
-| [provide-print-css](docs/rules/provide-print-css.md)                                   | Enforce providing a print stylesheet                       | ✅  |
+| Name                                                                                   | Description                                               | ⚠️ |
+| :------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- |
+| [avoid-brightness-override](docs/rules/avoid-brightness-override.md)                   | Should avoid to override brightness                       | ✅  |
+| [avoid-css-animations](docs/rules/avoid-css-animations.md)                             | Avoid usage of CSS animations                             | ✅  |
+| [avoid-high-accuracy-geolocation](docs/rules/avoid-high-accuracy-geolocation.md)       | Avoid using high accuracy geolocation in web applications | ✅  |
+| [limit-db-query-results](docs/rules/limit-db-query-results.md)                         | Should limit the number of returns for a SQL query        | ✅  |
+| [no-empty-image-src-attribute](docs/rules/no-empty-image-src-attribute.md)             | Disallow usage of image with empty source attribute       | ✅  |
+| [no-import-all-from-library](docs/rules/no-import-all-from-library.md)                 | Should not import all from library                        | ✅  |
+| [no-multiple-access-dom-element](docs/rules/no-multiple-access-dom-element.md)         | Disallow multiple access of same DOM element              | ✅  |
+| [no-multiple-style-changes](docs/rules/no-multiple-style-changes.md)                   | Disallow multiple style changes at once                   | ✅  |
+| [no-torch](docs/rules/no-torch.md)                                                     | Should not programmatically enable torch mode             | ✅  |
+| [prefer-collections-with-pagination](docs/rules/prefer-collections-with-pagination.md) | Prefer API collections with pagination                    | ✅  |
+| [prefer-shorthand-css-notations](docs/rules/prefer-shorthand-css-notations.md)         | Encourage usage of shorthand CSS notations                | ✅  |
+| [provide-print-css](docs/rules/provide-print-css.md)                                   | Enforce providing a print stylesheet                      | ✅  |
 
 <!-- end auto-generated rules list -->
 

--- a/eslint-plugin/lib/rules/avoid-high-accuracy-geolocation.js
+++ b/eslint-plugin/lib/rules/avoid-high-accuracy-geolocation.js
@@ -27,7 +27,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Avoid using high accuracy geolocation in web applications.",
+      description: "Avoid using high accuracy geolocation in web applications",
       category: "eco-design",
       recommended: "warn",
     },

--- a/eslint-plugin/lib/rules/no-multiple-access-dom-element.js
+++ b/eslint-plugin/lib/rules/no-multiple-access-dom-element.js
@@ -23,7 +23,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Disallow multiple access of same DOM element.",
+      description: "Disallow multiple access of same DOM element",
       category: "eco-design",
       recommended: "warn",
     },

--- a/eslint-plugin/lib/rules/no-multiple-style-changes.js
+++ b/eslint-plugin/lib/rules/no-multiple-style-changes.js
@@ -23,7 +23,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Disallow multiple style changes at once.",
+      description: "Disallow multiple style changes at once",
       category: "eco-design",
       recommended: "warn",
     },

--- a/eslint-plugin/lib/rules/prefer-collections-with-pagination.js
+++ b/eslint-plugin/lib/rules/prefer-collections-with-pagination.js
@@ -66,7 +66,7 @@ module.exports = {
   name: "prefer-collections-with-pagination",
   meta: {
     docs: {
-      description: "Prefer API collections with pagination.",
+      description: "Prefer API collections with pagination",
       category: "eco-design",
       recommended: "warn",
     },


### PR DESCRIPTION
Some of the rules descriptions have a trailing dot. All Sonar rules should not have one.
![image](https://github.com/user-attachments/assets/77aed54f-bd87-4b70-8c98-9080e9bb7256)
